### PR TITLE
fix item linking

### DIFF
--- a/current_spring2026/app.py
+++ b/current_spring2026/app.py
@@ -372,11 +372,7 @@ def format_card(doc: RetrievedDocument) -> dict:
     snippet   = doc.best_chunk_text[:300] if doc.best_chunk_text else ""
     full_text = doc.best_chunk_text if doc.best_chunk_text else ""
     tags     = list(set((doc.topics or []) + (doc.geography or [])))[:5]
-    url = (
-        f"https://www.digitalcommonwealth.org/search/commonwealth:{doc.ark_id}"
-        if doc.best_chunk_text
-        else f"https://www.digitalcommonwealth.org/collections/commonwealth:{doc.ark_id}"
-    )
+    url = f"https://www.digitalcommonwealth.org/search/commonwealth:{doc.ark_id}"
     thumbnail_url = (
         f"https://iiif.digitalcommonwealth.org/iiif/2/{doc.exemplary_image_id}/full/400,/0/default.jpg"
         if doc.exemplary_image_id and doc.exemplary_image_id.strip() else ""


### PR DESCRIPTION
This commit fixes the links to the items in DigitalCommonwealth.org in the search results display.

"Metadata" items and "full text" items should have the same link syntax; removed unnecessary logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized result card links across all search results. Previously, cards linked to different pages based on document content. Now all cards consistently link to the search page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->